### PR TITLE
feat: ModelCard modal reutilizável

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,6 +1,6 @@
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
-    <main className="min-h-screen flex items-center justify-center bg-gray-100 dark:bg-gray-900">
+    <main className="bg-login flex items-center justify-center dark:bg-gray-900">
       {children}
     </main>
   );

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,9 +1,47 @@
+"use client"
+
+import { ModalCard } from "@/app/_components/ModalCard";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { GoogleLogo } from "phosphor-react";
 
 
 export default function LoginPage() {
   return (
     <div className="flex items-center justify-center flex-col gap-4 h-screen">
-      <h1 className="text-gray-400 text-4xl">LOGIN PAGE</h1>
+
+
+      {/* MODELO ABAIXO DE TESTE PARA TESTAR O MODAL */}
+
+      <ModalCard title="Entrar" subtitle="Entre na sua conta Watchlist.">
+        <span>Email</span>
+        <Input />
+        <span>Senha</span>
+        <Input />
+        <span className="flex justify-end text-[13px] text-grayBrand-400">Esqueceu sua senha ?</span>
+
+        <Button className="mt-2">Entrar</Button>
+
+        <div className="flex  w-full justify-between items-center gap-2">
+          <span className="h-0.5 w-[70%] opacity-40 bg-gray-400"></span>
+          <span className="text-white font-bold">ou</span>
+          <span className="h-0.5 w-[70%] opacity-40 bg-gray-400"></span>
+        </div>
+        <div className="flex flex-col gap-6">
+          <Button variant={"outline"} className="flex justify-center items-center font-bold">
+            <GoogleLogo width={22} height={22} /> Continue com o Google
+          </Button>
+        </div>
+
+        <span className="h-0.5 w-[100%] opacity-40 bg-grayBrand-300 my-3"></span>
+
+        <div className="flex gap-14 justify-center items-center">
+          <span className="text-[14px] text-grayBrand-400">Nao tem uma conta ?</span>
+          <Button variant={"outline"} className="border-grayBrand-400">Cadastre-se gratuitamente</Button>
+        </div>
+      </ModalCard>
+
+      
     </div>
   );
 }

--- a/src/app/(private)/layout.tsx
+++ b/src/app/(private)/layout.tsx
@@ -1,6 +1,6 @@
 export default function PrivateLayout({ children }: { children: React.ReactNode }) {
   return (
-      <body>
+      <body className='bg-login'>
         <main className="">{children}</main>
       </body>
   );

--- a/src/app/_components/ModalCard.tsx
+++ b/src/app/_components/ModalCard.tsx
@@ -1,15 +1,12 @@
 import React from "react";
 import {
     Card,
-    CardAction,
     CardContent,
     CardDescription,
-    CardFooter,
     CardHeader,
     CardTitle,
 } from "@/components/ui/card"
 import Image from "next/image";
-import { Button } from "@/components/ui/button";
 
 interface ModalCardProps {
     title: string;
@@ -18,17 +15,17 @@ interface ModalCardProps {
     className?: string;
 }
 
-export function ModalCard({ title, subtitle, children, className = "" }: ModalCardProps) {
+export function ModalCard({ title, subtitle, children}: ModalCardProps) {
     return (
-        <Card className="bg-primary-600 w-full max-w-md p-5">
+        <Card className="bg-card w-full max-w-[480px] p-5 border-0">
 
-            <CardHeader className="">
+            <CardHeader>
                 <div className="flex flex-col items-center justify-center gap-6 mb-4">
                     <Image
                         alt="watchlist-logo"
                         src={'/assets/logos/watchlist-logo-white.webp'}
-                        width={150}
-                        height={80}
+                        width={120}
+                        height={50}
                         priority
                     />
 
@@ -45,25 +42,6 @@ export function ModalCard({ title, subtitle, children, className = "" }: ModalCa
             <CardContent className="flex flex-col gap-2 text-white">
                 {children}
             </CardContent>
-
-            <CardFooter className="flex flex-col items-center justify-between gap-3">
-                <div className="flex  w-full justify-between items-center gap-2">
-                    <span className="h-0.5 w-[70%] opacity-40 bg-gray-400"></span>
-                    <span className="text-white font-bold">ou</span>
-                    <span className="h-0.5 w-[70%] opacity-40 bg-gray-400"></span>
-                </div>
-                <div className="flex flex-col gap-6">
-                    <Button className="bg-white font-bold">
-                        Continue com o Google
-                    </Button>
-                    <span className="text-gray-100 text-sm">
-                        By clicking "Create account" above, you acknowledge that you will receive
-                        updates from the Watchlist team and that you have read, understood, and
-                        agreed to Terms & Conditions and
-                        Privacy Policy.
-                    </span>
-                </div>
-            </CardFooter>
         </Card>
     );
 }

--- a/src/app/_components/ModalCard.tsx
+++ b/src/app/_components/ModalCard.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import {
+    Card,
+    CardAction,
+    CardContent,
+    CardDescription,
+    CardFooter,
+    CardHeader,
+    CardTitle,
+} from "@/components/ui/card"
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+
+interface ModalCardProps {
+    title: string;
+    subtitle: string;
+    children: React.ReactNode; //Precisa ser do tipo ReactNode para aceitar componentes;
+    className?: string;
+}
+
+export function ModalCard({ title, subtitle, children, className = "" }: ModalCardProps) {
+    return (
+        <Card className="bg-primary-600 w-full max-w-md p-5">
+
+            <CardHeader className="">
+                <div className="flex flex-col items-center justify-center gap-6 mb-4">
+                    <Image
+                        alt="watchlist-logo"
+                        src={'/assets/logos/watchlist-logo-white.webp'}
+                        width={150}
+                        height={80}
+                        priority
+                    />
+
+                    <span className="h-0.5 w-[90%] opacity-40 bg-gray-400"></span>
+                </div>
+
+                <div className="text-white flex flex-col items-start justify-start gap-3 font-semiboldbold text-2xl">
+                    <CardTitle>{title}</CardTitle>
+                    <CardDescription className="text-gray-50">{subtitle}</CardDescription>
+                </div>
+
+            </CardHeader>
+
+            <CardContent className="flex flex-col gap-2 text-white">
+                {children}
+            </CardContent>
+
+            <CardFooter className="flex flex-col items-center justify-between gap-3">
+                <div className="flex  w-full justify-between items-center gap-2">
+                    <span className="h-0.5 w-[70%] opacity-40 bg-gray-400"></span>
+                    <span className="text-white font-bold">ou</span>
+                    <span className="h-0.5 w-[70%] opacity-40 bg-gray-400"></span>
+                </div>
+                <div className="flex flex-col gap-6">
+                    <Button className="bg-white font-bold">
+                        Continue com o Google
+                    </Button>
+                    <span className="text-gray-100 text-sm">
+                        By clicking "Create account" above, you acknowledge that you will receive
+                        updates from the Watchlist team and that you have read, understood, and
+                        agreed to Terms & Conditions and
+                        Privacy Policy.
+                    </span>
+                </div>
+            </CardFooter>
+        </Card>
+    );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -135,3 +135,57 @@ body {
   --sidebar-ring: oklch(0.556 0 0);
 }
 
+@layer utilities {
+  .bg-login {
+    @apply relative bg-[#121212] overflow-hidden;
+  }
+
+  .bg-login::before {
+    content: "";
+    position: absolute;
+    top: -200px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 800px;
+    height: 800px;
+    background-color: #3730a3; /* indigo-700 */
+    opacity: 0.4;
+    border-radius: 9999px;
+    filter: blur(200px);
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .bg-login > * {
+    position: relative;
+    z-index: 10;
+  }
+  
+}
+
+@layer utilities {
+  .bg-card {
+    @apply relative overflow-hidden backdrop-blur-md bg-[#121212]/80 border border-gray-800 rounded-xl;
+  }
+
+  .bg-card::before {
+    content: "";
+    position: absolute;
+    top: -200px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 800px;
+    height: 800px;
+    background-color: #3730a9; /* roxo */
+    opacity: 0.4;
+    border-radius: 9999px;
+    filter: blur(200px);
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .bg-card > * {
+    position: relative;
+    z-index: 10;
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,10 +3,11 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import Image from "next/image";
+import { ModalCard } from "./_components/ModalCard";
 
 export default function Home() {
   return (
-    <div className=" flex items-center justify-center flex-col gap-4 h-screen w-full max-w-5xl mx-auto">
+    <div className="flex items-center justify-center flex-col gap-4 h-screen w-full max-w-5xl mx-auto">
 
       <h1 className="text-black text-5xl font-bold">ÁREA DE TESTE DE COMPONENTES</h1>
 
@@ -24,6 +25,13 @@ export default function Home() {
 
       <span className="font-bold">Input abaixo com focus indigo-700:</span>
       <Input />
+
+      <ModalCard title="Inscrever-se" subtitle="Crie sua conta Watchlist.">
+        <span>Email</span>
+        <Input />
+        <Button>Continuar com email</Button>
+      </ModalCard>
+
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,9 +8,8 @@ import { ModalCard } from "./_components/ModalCard";
 export default function Home() {
   return (
     <div className="flex items-center justify-center flex-col gap-4 h-screen w-full max-w-5xl mx-auto">
-
+      
       <h1 className="text-black text-5xl font-bold">ÁREA DE TESTE DE COMPONENTES</h1>
-
       <Image
         alt="testeLogo"
         src={'/assets/logos/watchlist-logo-dark.webp'}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}


### PR DESCRIPTION
📄 Descrição

Este PR implementa o componente `ModelCard`, um modal reutilizável criado com base no `Card` do ShadCN. O objetivo é permitir o uso compartilhado do modal entre diferentes partes da aplicação.

Inclui:
- Instalação do componente `Card` via ShadCN UI.
- Criação do componente `ModelCard` dentro de `components/`.
- Props obrigatórios:
  - `title` (string)
  - `description` (string)
  - `children` (ReactNode)
- Definição de variáveis globais de cor no `global.css`:
  - `bg-login` (utilizado na página de login)
  - `bg-modal` (utilizado como fundo do card/modal principal)
- Testes realizados na página de login, deixando um exemplo de uso do modal.

✅ Checklist

- [x] Instalar `Card` via ShadCN.
- [x] Criar componente `ModelCard` com modal compartilhado.
- [x] Definir props obrigatórios (`title`, `description`, `children`).
- [x] Criar classes de background no `global.css` (`bg-login`, `bg-modal`).
- [x] Testar na página de login como exemplo.

📝 Observações

- O componente foi projetado para ser reutilizável em diversas partes da aplicação.
- Pode ser facilmente estendido com mais props ou estilos personalizados.
- Exemplo prático de uso foi adicionado à página de login para referência.
