### PR TITLE
Fix: Test IOS Safari background

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { BackgroundEclipses } from '@/components/Backgrounds/BackgroundEclipses';
+import { BackgroundTestIphone } from '@/components/Backgrounds/BackgroundTestIphone';
 import './globals.css';
 import ClientAuthProvider from '@/contexts/ClientAuthProvider';
 import { GoogleOAuthProvider } from '@react-oauth/google';
@@ -48,7 +49,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <ClientAuthProvider>
             <Toaster />
             <div>
-              <BackgroundEclipses />
+              <BackgroundTestIphone />
               {children}
             </div>
           </ClientAuthProvider>

--- a/src/components/Backgrounds/BackgroundTestIphone.tsx
+++ b/src/components/Backgrounds/BackgroundTestIphone.tsx
@@ -1,0 +1,17 @@
+export function BackgroundTestIphone() {
+  return (
+    <div className="pointer-events-none fixed inset-0 z-0 overflow-hidden">
+      {/* Eclipse do topo */}
+      <div
+        className="absolute top-[-300px] left-1/2 -translate-x-1/2 w-[700px] h-[700px] rounded-full blur-[200px] transform-gpu"
+        style={{ backgroundColor: 'rgba(67, 56, 202, 0.3)' }}
+      />
+
+      {/* Eclipse de baixo */}
+      <div
+        className="absolute bottom-[-300px] right-1/2 translate-x-1/2 w-[700px] h-[700px] rounded-full blur-[200px] transform-gpu"
+        style={{ backgroundColor: 'rgba(67, 56, 202, 0.1)' }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## 📄 Descrição

Este PR inclui as seguintes alterações:

- ✅ **Criação do componente de teste de background**: Adicionado o arquivo `BackgroundTestiPhone.tsx` para testar o comportamento de elementos com `blur` e transparência no Safari do iPhone.
- 🎨 **Compatibilidade Safari iOS**: Ajustes feitos usando `rgba` para cores com alpha e `transform-gpu` para forçar renderização correta no Safari.
- 🧹 **Código limpo e organizado**: Mantido apenas o necessário para o teste, facilitando futuras alterações.

---

## 🛠️ Alterações

- Criado arquivo `BackgroundTestiPhone.tsx` dentro da pasta `background`.
- Adicionado componente funcional que renderiza dois círculos (`div`) com `blur-[200px]` e cores transparentes via `rgba`.
- Aplicado `transform-gpu` para melhorar compatibilidade com Safari.
- Removidos usos de `opacity` separados, que causavam problemas no iOS.

---

## ✅ Checklist

- [x]  Código compila sem erros  
- [x]  Código limpo e organizado  
- [x]  Compatível com Tailwind CSS  

---