### PR TITLE
feat: add cardcarousel on cards and home, minor fixes

### DIFF
--- a/src/app/(private)/home/page.tsx
+++ b/src/app/(private)/home/page.tsx
@@ -1,29 +1,57 @@
-"use client"
+"use client";
 
 import { useEffect } from "react";
 import useAnimeApi from "@/hooks/useAnimeApi";
-import { CardPreview } from "@/components/Cards/CardPreview";
 import { CardSkeleton } from "@/components/Cards/CardSkeleton";
-
+import Carousel from "@/components/Cards/CardCarousel"; // 👈 importa o carrossel
+import { Library, Popcorn } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import CardsCarousel from "@/components/Cards/CardCarousel";
 
 export default function Home() {
-
   const { animes, loading, getTopAnimes } = useAnimeApi();
 
   useEffect(() => {
-    getTopAnimes()
-  }, [])
+    getTopAnimes();
+  }, []);
 
   return (
-    <div className="bg-background flex items-center justify-center flex-col gap-4 min-h-screen">
-      <div className="flex flex-wrap gap-10 justify-center p-8">
-        {loading
-          ? Array(10)
-            .fill(0)
-            .map((_, i) => <CardSkeleton key={i} />)
-          : animes.map((anim) => <CardPreview key={anim.mal_id} {...anim} />)}
+    <div className="bg-background text-white flex flex-col min-h-screen m-auto gap-8 transation duration-200 w-full">
+      <div className="w-full flex p-8 items-center">
+        {loading ? (
+          // skeletons
+          <div className="relative overflow-hidden w-full">
+            <div className="flex overflow-x-auto scrollbar-hide scroll-smooth gap-6 px-4">
+              {Array(8).fill(0).map((_, i) => (
+                <div key={i} className="flex-shrink-0">
+                  <CardSkeleton />
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : animes.length === 0 ? (
+          // vazio
+          <div className="flex flex-col items-center justify-center text-center p-6 max-w-xl mx-auto mt-20">
+            <div className="text-5xl mb-4">
+              <Popcorn />
+            </div>
+            <h2 className="text-2xl font-semibold text-white">
+              Nada em andamento por aqui
+            </h2>
+            <p className="text-sm text-gray-400 mb-4">
+              <Button variant='link' className="p-0 underline underline-offset-4">
+                <Link href='/create'>Adicione</Link>
+              </Button>{" "}
+              o que está vendo ou lendo para não perder o ponto onde parou.
+            </p>
+          </div>
+        ) : (
+          // carrossel
+          <CardsCarousel cards={animes} />
+        )}
+
       </div>
     </div>
   );
-
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,6 +26,14 @@ body {
   font-family: 'Inter', sans-serif;
 }
 
+.scrollbar-hide {
+  -ms-overflow-style: none; /* IE 10+ */
+  scrollbar-width: none;    /* Firefox */
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Opera */
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/src/components/Cards/CardCarousel.tsx
+++ b/src/components/Cards/CardCarousel.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { CardData } from "@/types/ApiTypes";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useRef } from "react";
+import { CardPreview } from "@/components/Cards/CardPreview";
+
+interface CardsCarouselProps {
+  cards: CardData[];
+}
+
+export default function CardsCarousel({ cards }: CardsCarouselProps) {
+  const carouselRef = useRef<HTMLDivElement>(null);
+
+  function scroll(direction: "left" | "right") {
+    if (carouselRef.current) {
+      const scrollAmount = carouselRef.current.offsetWidth * 0.8;
+      carouselRef.current.scrollBy({
+        left: direction === "left" ? -scrollAmount : scrollAmount,
+        behavior: "smooth",
+      });
+    }
+  }
+
+  return (
+    <div className="relative overflow-hidden w-full">
+      {/* seta esquerda */}
+      <button
+        onClick={() => scroll("left")}
+        className="absolute left-0 top-1/2 -translate-y-1/2 z-10 bg-black/70 hover:bg-black/90 text-white p-3 rounded-full hidden md:flex cursor-pointer transition-all duration-200 backdrop-blur-sm border border-gray-700"
+        aria-label="Scroll Left"
+      >
+        <ChevronLeft size={20} />
+      </button>
+
+      {/* trilho do carrossel */}
+      <div
+        ref={carouselRef}
+        className="flex overflow-x-auto scrollbar-hide scroll-smooth gap-6 px-4 max-w-full"
+      >
+        {cards.map((item) => (
+          <div key={item.mal_id} className="flex-shrink-0">
+            <CardPreview {...item} />
+          </div>
+        ))}
+      </div>
+
+      {/* seta direita */}
+      <button
+        onClick={() => scroll("right")}
+        className="absolute right-0 top-1/2 -translate-y-1/2 z-10 bg-black/70 hover:bg-black/90 text-white p-3 rounded-full hidden md:flex cursor-pointer transition-all duration-200 backdrop-blur-sm border border-gray-700"
+        aria-label="Scroll Right"
+      >
+        <ChevronRight size={20} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/Cards/CardPreview.tsx
+++ b/src/components/Cards/CardPreview.tsx
@@ -9,12 +9,12 @@ function getImageUrl(image_url: string) {
     return image_url || "/assets/default-image.png";
 }
 
-export function CardPreview({ mal_id, title, score, types, aired_from, image_url }: CardData) {
-    const [favorito, setFavorito] = useState(false);
+export function CardPreview({ title, score, types, aired_from, image_url }: CardData) {
+    const [favorite, setFavorite] = useState<boolean>(false);
 
     return (
         <div
-            className={"relative w-[288px] h-[395px] rounded-2xl overflow-hidden"}
+            className={"relative flex max-w-[288px] max-h-[395px] rounded-2xl"}
         >
             <Image
                 src={getImageUrl(image_url)}
@@ -41,12 +41,12 @@ export function CardPreview({ mal_id, title, score, types, aired_from, image_url
                         </div>
                     )}
                     <button
-                        onClick={() => setFavorito(!favorito)}
+                        onClick={() => setFavorite(!favorite)}
                         className="bg-grayBrand-900 p-2 flex rounded-full items-center justify-center"
                     >
                         <Heart
                             size={18}
-                            className={favorito ? "text-purple-500 fill-purple-500" : "text-grayBrand-500"}
+                            className={favorite ? "text-purple-500 fill-purple-500" : "text-grayBrand-500"}
                         />
                     </button>
                 </div>

--- a/src/components/Cards/CardSkeleton.tsx
+++ b/src/components/Cards/CardSkeleton.tsx
@@ -1,8 +1,6 @@
 export function CardSkeleton() {
   return (
     <div className="relative w-[288px] h-[395px] rounded-2xl overflow-hidden bg-gray-700 animate-pulse">
-      
-      <div className="absolute bottom-0 left-0 w-full h-36 bg-gradient-to-t from-gray-700 to-gray-600"></div>
 
       <div className="absolute w-full p-3 bottom-1 left-0 flex flex-col gap-2">
         <div className="flex w-full justify-between mb-1">

--- a/src/hooks/useAnimeApi.ts
+++ b/src/hooks/useAnimeApi.ts
@@ -32,7 +32,7 @@ function normalizeNew(item: DataItem): CardData[] {
 
 export default function useAnimeApi() {
   const [animes, setAnimes] = useState<CardData[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   const getTopAnimes = async () => {
     setLoading(true);


### PR DESCRIPTION
## Added incomplete card carousel

- Adicionado: CardCarousel
- Alterações: global.css (adicionei smooth scrollbar e hide), home (mudei a chamada do carousel)
- Arrumei o estado de loading o useAnimeApi - Disparando loading antes mesmo de estar carregando
- Mudanças no tamanho do cardpreview: antes era w-[288px], agora é max-w-[288px] para suportar o carousel corretamente
- Mudanças no favorito para favorite
- Removi a tentativa de degrade do skeleton pro cardpreview, achei estranho

<img width="1180" height="568" alt="image" src="https://github.com/user-attachments/assets/be33140b-879d-4dc4-b009-7e6bc2428631" />
